### PR TITLE
Updated request package. Added gzip support

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mkdirp": "^0.5.1",
     "morgan": "^1.6.1",
     "pify": "^2.3.0",
-    "request": "^2.67.0",
+    "request": "^2.81.0",
     "serve-favicon": "^2.3.0",
     "toml": "^2.3.0",
     "touch": "^1.0.0",

--- a/src/app-utils.js
+++ b/src/app-utils.js
@@ -104,9 +104,14 @@ export function resolveMockPath (req, dataRoot) {
 }
 
 export function passthru (res, options) {
+  const zlib = require('zlib');
   try {
     res.writeHead(options.code || 200, options.headers);
-    res.write(options.body);
+    if (options.headers['content-encoding'] && options.headers['content-encoding'] === 'gzip') {
+      res.write(zlib.gzipSync(options.body));
+    } else {
+      res.write(options.body);
+    }
     res.end();
   } catch (e) {
     console.warn('Error writing response', e);

--- a/src/delay-middleware.js
+++ b/src/delay-middleware.js
@@ -1,0 +1,25 @@
+const timers = require('timers');
+
+const create_delayer = function() {
+  return function(req, res, next) {
+    const end = res.end;
+
+    if (!req.conf || !req.conf.delay) {
+      return next();
+    }
+
+    const time = req.conf.delay;
+
+    res.end = function() {
+      const args = arguments;
+      console.log(args)
+      timers.setTimeout(function() {
+        end.apply(res, args);
+      }, time);
+    };
+
+    next();
+  };
+};
+
+module.exports = create_delayer;

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import mappings from './mappings';
 import props from './props';
 import cache from './cache-middleware';
 import mockproxy from './mock-proxy';
+import delay from './delay-middleware';
 
 var appRoot = join(__dirname, '..');
 
@@ -18,6 +19,7 @@ app.use(logger('dev'));
 app.use(bodyParser.raw(mappings.bodyParserConfig));
 // Setup proxy middleware
 app.use(mappings());
+app.use(delay());
 app.use(props());
 app.use(cache());
 app.use(mockproxy());

--- a/src/mappings.js
+++ b/src/mappings.js
@@ -26,7 +26,8 @@ const middleware = () => (req, res, next) => {
       contentType: mapping.contentType,
       noproxy: mapping.noproxy,
       nocache: mapping.nocache,
-      touchFiles: mapping.touchFiles
+      touchFiles: mapping.touchFiles,
+      delay: mapping.delay
     };
     req.conf = conf;
     req.urlToProxy = reqUrl.replace(key, '');

--- a/src/mock-proxy.js
+++ b/src/mock-proxy.js
@@ -41,6 +41,9 @@ const middleware = () => (req, res, next) => {
   const url = req.conf.host + req.urlToProxy;
   const method = req.method.toLowerCase();
   const urlConf = {url, timeout, headers: req.headers};
+  if (urlConf.headers['accept-encoding'] && urlConf.headers['accept-encoding'] === 'gzip') {
+    urlConf.gzip = true;
+  }
   // Remove encoding because we've processed the body already.
   delete urlConf.headers['content-encoding'];
   // Reset host


### PR DESCRIPTION
- If body content is compressed, save decompressed body content
- When serving content if header's content-encoding is set to gzip, gzip the body then send