### PR TITLE
Added support for delaying response per mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ contentType = "application/json"
 noproxy = false # Don't proxy for this mapping
 nocache = false # Don't use the cache for this mapping
 touchFiles = false # Touch cache files for this mapping
+delay = 1000 # Add a delay of 1000 ms to the response
 
 # You can have as many mappings as you'd like:
 [mappings.twitter]

--- a/src/delay-middleware.js
+++ b/src/delay-middleware.js
@@ -1,0 +1,24 @@
+const timers = require('timers');
+
+const create_delayer = function() {
+  return function(req, res, next) {
+    const end = res.end;
+
+    if (!req.conf || !req.conf.delay) {
+      return next();
+    }
+
+    const time = req.conf.delay;
+
+    res.end = function() {
+      const args = arguments;
+      timers.setTimeout(function() {
+        end.apply(res, args);
+      }, time);
+    };
+
+    next();
+  };
+};
+
+module.exports = create_delayer;

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import mappings from './mappings';
 import props from './props';
 import cache from './cache-middleware';
 import mockproxy from './mock-proxy';
+import delay from './delay-middleware';
 
 var appRoot = join(__dirname, '..');
 
@@ -18,6 +19,7 @@ app.use(logger('dev'));
 app.use(bodyParser.raw(mappings.bodyParserConfig));
 // Setup proxy middleware
 app.use(mappings());
+app.use(delay());
 app.use(props());
 app.use(cache());
 app.use(mockproxy());

--- a/src/mappings.js
+++ b/src/mappings.js
@@ -26,7 +26,8 @@ const middleware = () => (req, res, next) => {
       contentType: mapping.contentType,
       noproxy: mapping.noproxy,
       nocache: mapping.nocache,
-      touchFiles: mapping.touchFiles
+      touchFiles: mapping.touchFiles,
+      delay: mapping.delay
     };
     req.conf = conf;
     req.urlToProxy = reqUrl.replace(key, '');


### PR DESCRIPTION
By adding `delay: <timeInMs>` to a mapping, the response will be delayed by the specified milliseconds.