### PR TITLE
ignore ssl certs as config property

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Here is a fully annotated configuration file in TOML showing all of the availabl
 host = "localhost"
 port = 8088
 # These are the default values
+ignoreSSL = false
+# false by default, ignores unsigned cert
 
 [proxy]
 timeout = 5000

--- a/src/serve.js
+++ b/src/serve.js
@@ -6,6 +6,11 @@ export default function () {
 
   const port = server.port || 8088;
   const host = server.host || 'localhost';
+  const ignoreSSL = server.ignoreSSL;
+  if (ignoreSSL) {
+    console.log('[WARNING] ignoring SSL certs, use with caution!');
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  }
   console.log('Starting server: [http://%s:%s]', host, port);
   app.listen(port, host);
 }


### PR DESCRIPTION
Unsigned or/and self signed certs causing node server to crash, this is simple configuration parameter to ignore them - of course it isn't best way to do it, but should be enough for this app.