### PR TITLE
Bugfix/QueryString

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "serve-favicon": "^2.3.0",
     "toml": "^2.3.0",
     "touch": "^1.0.0",
-    "type-is": "^1.6.10"
+    "type-is": "^1.6.10",
+    "qs": "latest"
   },
   "devDependencies": {
     "assert": "~1.3.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "toml": "^2.3.0",
     "touch": "^1.0.0",
     "type-is": "^1.6.10",
-    "qs": "latest"
+    "qs": "^6.7.0"
   },
   "devDependencies": {
     "assert": "~1.3.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint": "semistandard",
     "unit": "mocha",
     "test": "npm run lint",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/app-utils.js
+++ b/src/app-utils.js
@@ -1,5 +1,5 @@
 import {parse} from 'url';
-import querystring from 'querystring';
+import querystring from 'qs';
 import {join} from 'path';
 
 // Utility methods


### PR DESCRIPTION
This pull request fixes the issue of nested objects in a JSON payload sent through a POST request. 

https://github.com/nodejs/node-v0.x-archive/issues/1665

The library "querystring" is replaced with "qs". This packed was already installed via dependancy. 

The "qs" package has an export "stringify" so no additional coding was required. 
( I got pretty lucky )

I have also added the following to the package.json
`"prepare": "npm run build"`

I could not get npm to download the forked repository with src files. It expects the download to already be compiled unless the above snippet is attached. GitHub doesn't build the project like npm, so the only other trivial ways to achieve collaborating was to add my fork to npm or remove lib from the .gitignore and commit the folder to github. These two options seemed excessive when compared with the above, so I suggest leaving it in the package. I am not a node expert, so if this is a breaking change then we should possibly just add the process to the documentation. 

Best,
Richard Miles
